### PR TITLE
CORS support

### DIFF
--- a/src/main/java/com/st/novatech/springlms/SpringlmsApplication.java
+++ b/src/main/java/com/st/novatech/springlms/SpringlmsApplication.java
@@ -2,7 +2,10 @@ package com.st.novatech.springlms;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.PropertySource;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 /**
  * Main driver class for the application for running from the command line.
@@ -13,10 +16,26 @@ public class SpringlmsApplication {
 
 	/**
 	 * Main method.
+	 *
 	 * @param args parsed by Spring
 	 */
 	public static void main(final String[] args) {
 		SpringApplication.run(SpringlmsApplication.class, args);
 	}
 
+	/**
+	 * Enable cross-origin requests.
+	 *
+	 * @return the CORS filter
+	 */
+	@Bean
+	public WebMvcConfigurer corsConfigurer() {
+		return new WebMvcConfigurer() {
+			@Override
+			public void addCorsMappings(final CorsRegistry registry) {
+				registry.addMapping("/**").allowedMethods("GET", "POST", "PUT",
+						"DELETE", "HEAD");
+			}
+		};
+	}
 }


### PR DESCRIPTION
This PR adds the necessary headers to allow cross-origin requests. This is necessary for a client-side-scripted frontend to be able to make REST calls to this service.