### PR TITLE
Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>8.0.15</version>
+			<version>8.0.16</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/com.h2database/h2 -->

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.6.RELEASE</version>
+		<version>2.1.7.RELEASE</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.st.novatech</groupId>
@@ -18,7 +18,7 @@
 	<properties>
 		<java.version>1.8</java.version>
 		<junit-jupiter.version>5.4.0</junit-jupiter.version>
-		<!-- <jackson.version>2.9.9.1</jackson.version> -->  <!-- Uncomment as soon as FasterXML/jackson-bom#22 merged -->
+		<jackson.version>2.9.9.20190807</jackson.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
 	<properties>
 		<java.version>1.8</java.version>
 		<junit-jupiter.version>5.4.0</junit-jupiter.version>
+		<!-- <jackson.version>2.9.9.1</jackson.version> -->  <!-- Uncomment as soon as FasterXML/jackson-bom#22 merged -->
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
This PR (which I will merge to my own fork's `master` branch essentially immediately, but opened here "upstream" as well rather than leave it completely vulnerable) bumps the `mysql-connector` dependency from a version with a known security vulnerability to the latest version, and (commented out, pending FasterXML/jackson-bom#22) the Jackson dependency from a version with several known dependencies to its latest version.